### PR TITLE
feat: define fixed workspaces which will always move with you between contexts

### DIFF
--- a/XMonad/Actions/Contexts.hs
+++ b/XMonad/Actions/Contexts.hs
@@ -125,13 +125,12 @@ mergeContexts ids ctxOld ctxNew = do
 
 -- set the window set and apply the workspaceNames
 setWindowsAndWorkspaces :: Context -> Context -> X ()
-setWindowsAndWorkspaces oldContext newContext = do
+setWindowsAndWorkspaces fixedWs oldContext newContext = do
 
     -- copy fixed workspaces from curren context
-    let newContext = mergeContexts [ "l" ] oldContext newContext
+    let mergedContext = mergeContexts fixedWs oldContext newContext
 
-    -- let Context windowSet workspaceNames = newContext
-    let Context windowSet workspaceNames = newContext
+    let Context windowSet workspaceNames = mergedContext
 
     windows $ const windowSet -- hide old windows and show windows from new context
     mapM_ (uncurry setWorkspaceName) workspaceNames


### PR DESCRIPTION
I often have one or more workspaces with things like my chat, music player, or similar programs that I want in all contexts. 

This merge allowes the user to use, for example, the `createAndSwitchFixedWs` function with a list of workspace tags that will be fixed